### PR TITLE
Fix typo in aggregates.sh

### DIFF
--- a/extensions/sparql-protocol/temporal-data/aggregates.sh
+++ b/extensions/sparql-protocol/temporal-data/aggregates.sh
@@ -20,7 +20,7 @@ _:b ex:start "2014-01-01T00:00:00Z"^^xsd:dateTime ;
 _:c ex:start "2014-01-01T00:00:00Z"^^xsd:dateTime ;
   ex:end "2014-02-01T00:00:00Z"^^xsd:dateTime .
 
-_:b ex:start "2014-01-01T00:00:00Z"^^xsd:dateTime ;
+_:d ex:start "2014-01-01T00:00:00Z"^^xsd:dateTime ;
   ex:end "2015-01-01T00:00:00Z"^^xsd:dateTime .
 EOF
 


### PR DESCRIPTION
Small error in name of blank node: `_:b` changed to `_:d` on line 23
